### PR TITLE
task7: authorization

### DIFF
--- a/bin/shop-aws.ts
+++ b/bin/shop-aws.ts
@@ -4,8 +4,16 @@ import * as cdk from "aws-cdk-lib";
 import { CloudXAppStack } from "../lib/cloudx-app-stack";
 import { ProductServiceStack } from "../lib/product-service-stack/product-service-stack";
 import { ImportServiceStack } from "../lib/import-service-stack/import-service-stack";
+import { AuthorizationServiceStack } from "../lib/authorization-service-stack/authorization-service-stack";
 
 const app = new cdk.App();
+
+new AuthorizationServiceStack(app, "AuthorizationServiceStack", {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});
 
 const productServiceStack = new ProductServiceStack(
   app,

--- a/lib/authorization-service-stack/authorization-service-stack.ts
+++ b/lib/authorization-service-stack/authorization-service-stack.ts
@@ -1,0 +1,30 @@
+import * as cdk from "aws-cdk-lib";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as path from "path";
+import { Construct } from "constructs";
+
+export class AuthorizationServiceStack extends cdk.Stack {
+  public readonly basicAuthorizer: lambda.Function;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    this.basicAuthorizer = new lambda.Function(this, "BasicAuthorizer", {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      memorySize: 128,
+      timeout: cdk.Duration.seconds(5),
+      handler: "index.main",
+      code: lambda.Code.fromAsset(
+        path.join(__dirname, "../../dist/basicAuthorizer")
+      ),
+      environment: {
+        [process.env.GITHUB_USERNAME || "atillacantay"]: "test123",
+      },
+    });
+
+    new cdk.CfnOutput(this, "BasicAuthorizerArn", {
+      value: this.basicAuthorizer.functionArn,
+      description: "ARN of the Basic Authorizer Lambda function",
+    });
+  }
+}

--- a/lib/authorization-service-stack/basicAuthorizer.ts
+++ b/lib/authorization-service-stack/basicAuthorizer.ts
@@ -1,0 +1,29 @@
+import { APIGatewayTokenAuthorizerEvent } from "aws-lambda";
+import {
+  validateAuthorizationToken,
+  decodeBasicAuthToken,
+  validateCredentials,
+  createSuccessResponse,
+  type AuthResult,
+} from "./utils/auth-utils";
+
+export const main = async (
+  event: APIGatewayTokenAuthorizerEvent
+): Promise<AuthResult> => {
+  console.log("Authorization event:", JSON.stringify(event, null, 2));
+
+  const authorizationToken = event.authorizationToken;
+
+  try {
+    validateAuthorizationToken(authorizationToken);
+
+    const { username, password } = decodeBasicAuthToken(authorizationToken);
+
+    validateCredentials(username, password);
+
+    return createSuccessResponse(username);
+  } catch (error) {
+    console.error("Authorization error:", error);
+    throw new Error("Unauthorized");
+  }
+};

--- a/lib/authorization-service-stack/utils/auth-utils.ts
+++ b/lib/authorization-service-stack/utils/auth-utils.ts
@@ -1,0 +1,81 @@
+interface AuthResult {
+  principalId: string;
+  policyDocument: {
+    Version: string;
+    Statement: Array<{
+      Action: string;
+      Effect: string;
+      Resource: string;
+    }>;
+  };
+  context?: {
+    username: string;
+  };
+}
+
+export const validateAuthorizationToken = (
+  authorizationToken: string
+): AuthResult | null => {
+  if (!authorizationToken) {
+    console.log("No authorization token provided - returning 401");
+    throw new Error("Unauthorized: No authorization token provided");
+  }
+
+  if (!authorizationToken.startsWith("Basic ")) {
+    console.log("Invalid authorization token format - returning 401");
+    throw new Error("Unauthorized: Invalid authorization token format");
+  }
+
+  return null;
+};
+
+export const decodeBasicAuthToken = (
+  authorizationToken: string
+): { username: string; password: string } => {
+  const token = authorizationToken.substring(6);
+  const decodedToken = Buffer.from(token, "base64").toString("utf-8");
+  console.log("Decoded authorization token:", decodedToken);
+
+  const [username, password] = decodedToken.split(":");
+
+  console.log("Decoded username:", username);
+
+  return { username, password };
+};
+
+export const validateCredentials = (
+  username: string,
+  password: string
+): AuthResult | null => {
+  const expectedPassword = process.env[username];
+
+  if (!expectedPassword || expectedPassword !== password) {
+    console.log("Invalid credentials for user:", username, "- returning 403");
+    throw new Error("Forbidden: Invalid credentials");
+  }
+
+  return null;
+};
+
+export const createSuccessResponse = (username: string): AuthResult => {
+  console.log("Authorization successful for user:", username);
+
+  return {
+    principalId: username,
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "execute-api:Invoke",
+          Effect: "Allow",
+          Resource: "*",
+        },
+      ],
+    },
+    context: {
+      username: username,
+    },
+  };
+};
+
+export type { AuthResult };

--- a/lib/import-service-stack/importProductsFile.ts
+++ b/lib/import-service-stack/importProductsFile.ts
@@ -72,6 +72,6 @@ const getCorsHeaders = () => {
   return {
     "Access-Control-Allow-Origin": ALLOWED_ORIGINS,
     "Access-Control-Allow-Credentials": true,
-    "Access-Control-Allow-Methods": "GET",
+    "Access-Control-Allow-Methods": "GET, PUT, OPTIONS",
   };
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "deploy": "npx aws-cdk deploy",
     "deploy:service": "npm run build:webpack && npx aws-cdk deploy ProductServiceStack",
     "deploy:import": "npm run build:webpack && npx aws-cdk deploy ImportServiceStack",
+    "deploy:authorization": "npm run build:webpack && npx aws-cdk deploy AuthorizationServiceStack",
     "deploy:app": "npx aws-cdk deploy CloudXAppStack",
     "destroy": "npx aws-cdk destroy",
     "invalidate:cloudfront": "aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*'",

--- a/resources/build/index.html
+++ b/resources/build/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My shop</title>
-    <script type="module" crossorigin src="/assets/index.ac0966c7.js"></script>
+    <script type="module" crossorigin src="/assets/index.55dd2ba3.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -14,6 +14,7 @@ const config: webpack.Configuration = {
     catalogBatchProcess: "./lib/product-service-stack/catalogBatchProcess.ts",
     importProductsFile: "./lib/import-service-stack/importProductsFile.ts",
     importFileParser: "./lib/import-service-stack/importFileParser.ts",
+    basicAuthorizer: "./lib/authorization-service-stack/basicAuthorizer.ts",
   },
   output: {
     path: path.resolve(__dirname, "dist"),


### PR DESCRIPTION
# Task 7 - Authorization

## What was done?

- Created Authorization Service with `basicAuthorizer` Lambda function
- Implemented Basic Authentication using GitHub username `atillacantay` and `test123` password
- Added Lambda authorization to Import Service `/import` endpoint
- Configured environment variables securely using `.env` file
- Updated API Gateway with custom authorizer (401/403 error handling)

Security Features
Basic Auth with GitHub credentials (`atillacantay:test123`)
Lambda authorizer for API Gateway endpoints
Proper HTTP status codes (401/403) for auth failures

## Links
- Frontend: https://d3tp9ygejbpchq.cloudfront.net
- API Documentation: https://atilla-cloudx-import-service.apidocumentation.com/reference, https://atilla-cloudx-product-service.apidocumentation.com/reference

## AWS Dashboard Photos
Lambda functions
![Screenshot 2025-05-31 at 22 41 49](https://github.com/user-attachments/assets/0a778501-994e-46fc-a63d-90fb40e69fc8)

Authorizer Logs
![Screenshot 2025-05-31 at 22 47 49](https://github.com/user-attachments/assets/535ca9f0-a456-4df8-b378-ad5de09b99e4)



